### PR TITLE
Veranderingen adhv feedback

### DIFF
--- a/CampingD1/Database/DatabaseQueryHandler.cs
+++ b/CampingD1/Database/DatabaseQueryHandler.cs
@@ -172,8 +172,9 @@ WHERE
                 int max_persons = Convert.ToInt32(row["max_persons"]);
                 double price_m2 = Convert.ToDouble(row["price_m2"]);
                 bool available = Convert.ToBoolean(row["available"]);
+                string spotName = row["spot_name"].ToString();
 
-                campingSpot = new CampingSpot(id, description, surface_m2, power, water, wifi, max_persons, price_m2, available);
+                campingSpot = new CampingSpot(id, description, surface_m2, power, water, wifi, max_persons, price_m2, available, spotName);
             }
         }
         catch (Exception ex)
@@ -309,9 +310,10 @@ WHERE
                 int max_persons = Convert.ToInt32(row["max_persons"]);
                 double price_m2 = Convert.ToDouble(row["price_m2"]);
                 bool available = Convert.ToBoolean(row["available"]);
+                string spotName = row["spot_name"].ToString();
 
                 CampingSpot campingSpot = new CampingSpot(id, description, surface_m2, power, water, wifi, max_persons,
-                    price_m2, available);
+                    price_m2, available, spotName);
                 campingSpots.Add(campingSpot);
             }
         }

--- a/CampingD1/Database/Types/CampingSpot.cs
+++ b/CampingD1/Database/Types/CampingSpot.cs
@@ -17,6 +17,7 @@ namespace Database.Types
         public int MaxPersons { get; set; }
         public double Price_m2 { get; set; }
         public bool Available { get; set; }
+        public string SpotName { get; set; }
 
         // Formatted properties
         public string AvailableText => Available ? "Ja" : "Nee";
@@ -24,7 +25,7 @@ namespace Database.Types
         public string WaterText => Water ? "Ja" : "Nee";
         public string WifiText => Wifi ? "Ja" : "Nee";
 
-        public CampingSpot(int id, string description, double surface, bool power, bool water, bool wifi, int maxPersons, double price, bool available) 
+        public CampingSpot(int id, string description, double surface, bool power, bool water, bool wifi, int maxPersons, double price, bool available, string spotName) 
         {
             Id = id;
             Description = description;
@@ -35,6 +36,7 @@ namespace Database.Types
             MaxPersons = maxPersons;
             Price_m2 = price;
             Available = available;
+            SpotName = spotName;
         }
     }
 }

--- a/CampingD1/ReservationApp/MapScreenCustomer.xaml
+++ b/CampingD1/ReservationApp/MapScreenCustomer.xaml
@@ -40,6 +40,7 @@
             VerticalOptions="Center"
             HorizontalOptions="Center" />
 
+
         <!-- Date pickers in a horizontal layout -->
         <HorizontalStackLayout Spacing="20" HorizontalOptions="Center" VerticalOptions="Center">
             <StackLayout VerticalOptions="Center" Spacing="5">
@@ -48,17 +49,10 @@
             FontSize="16"
             FontAttributes="Bold"
             HorizontalOptions="Center"
-            TextColor="#333" />
-                <Frame Padding="5" BackgroundColor="#f0f0f0" CornerRadius="10" HasShadow="True" BorderColor="#dcdcdc">
-                    <DatePicker 
-                x:Name="arrivalDatePicker"
-                Date="{Binding ArrivalDate}"
-                VerticalOptions="Center"
-                BackgroundColor="White"
-                TextColor="Black"
-                HeightRequest="50"
-                WidthRequest="200"
-                 />
+            TextColor="#FFFFFF" />
+                <Frame Padding="5" BackgroundColor="#f0f0f0" CornerRadius="10" HasShadow="False" BorderColor="#dcdcdc">
+                    <DatePicker x:Name="arrivalDatePicker"
+            Format="dd MMMM yyyy" />
                 </Frame>
             </StackLayout>
 
@@ -68,29 +62,22 @@
             FontSize="16"
             FontAttributes="Bold"
             HorizontalOptions="Center"
-            TextColor="#333" />
+            TextColor="#FFFFFF" />
                 <Frame Padding="5" BackgroundColor="#f0f0f0" CornerRadius="10" HasShadow="True" BorderColor="#dcdcdc">
-                    <DatePicker 
-                x:Name="departureDatePicker"
-                Date="{Binding DepartureDate}"
-                VerticalOptions="Center"
-                BackgroundColor="White"
-                TextColor="Black"
-                HeightRequest="50"
-                WidthRequest="200"
-                />
+                    <DatePicker x:Name="departureDatePicker"
+            Format="dd MMMM yyyy" />
                 </Frame>
             </StackLayout>
         </HorizontalStackLayout>
 
         <HorizontalStackLayout Spacing="20" HorizontalOptions="Center" VerticalOptions="Center">
-            <Button 
+            <!--       <Button 
         Text="Zoek Beschikbaarheid"
         HorizontalOptions="Center"
         VerticalOptions="Center"
         WidthRequest="200"
-        HeightRequest="50"
-        Clicked="OnSearchAvailabilityClicked" />
+        HeightRequest="50"/>
+            Clicked="OnSearchAvailabilityClicked" /> -->
 
             <Button 
         Text="Ik heb een reservering"
@@ -103,7 +90,7 @@
         </HorizontalStackLayout>
 
         <!-- Search availability button -->
-        
+
         <!-- Grid with the map -->
         <Grid Padding="0">
             <!-- Main Content -->

--- a/CampingD1/ReservationApp/MapScreenCustomer.xaml.cs
+++ b/CampingD1/ReservationApp/MapScreenCustomer.xaml.cs
@@ -15,38 +15,34 @@ public partial class MapScreenCustomer : ContentPage
     public MapScreenCustomer()
     {
         InitializeComponent();
+        LoadCampingMap();
+
+        // Stel de standaardwaarden voor de date pickers in
+        arrivalDatePicker.Date = DateTime.Today;
+        departureDatePicker.Date = DateTime.Today.AddDays(1);
+
     }
 
-    private async void OnSearchAvailabilityClicked(object sender, EventArgs e)
+    private async void LoadCampingMap()
     {
         try
         {
-            // Laad de kaarten pas wanneer de zoekbeschikbaarheid knop wordt geklikt
+            // Zorg ervoor dat de database verbinding is gemaakt
             await Task.Run(() => App.databaseHandler.EnsureConnection());
 
+            // Haal de kaarten op
             var maps = await Task.Run(() => App.Database.SelectCampingMaps());
 
-            // RenderCampingMap(maps.First());
-            // CampingMap? primaryMap = maps.FirstOrDefault(map => map.isPrimary);
-
-            foreach (var map in maps) {
-                if (map.isPrimary == true) {
+            foreach (var map in maps)
+            {
+                if (map.isPrimary == true)
+                {
                     RenderCampingMap(map);
                     return;
                 }
             }
 
-            // if (primaryMap.HasValue == false)
-            // {
-            //     // Render the primary map
-            //     RenderCampingMap(primaryMap.Value);
-            // }
-            // else
-            // {
-            //     await DisplayAlert("No Primary Map", "No primary camping map found.", "OK");
-            // }
             await DisplayAlert("Oeps", "Er kan geen kaart gevonden worden", "OK");
-
         }
         catch (Exception ex)
         {
@@ -139,5 +135,4 @@ public partial class MapScreenCustomer : ContentPage
             }
         }
     }
-
 }

--- a/CampingD1/ReservationApp/ReservationPage.xaml
+++ b/CampingD1/ReservationApp/ReservationPage.xaml
@@ -8,7 +8,7 @@
         <StackLayout Padding="20" Spacing="20">
 
             <StackLayout Orientation="Horizontal" HorizontalOptions="Start" Spacing="1">
-                <Label Text="Locatie" FontSize="24" VerticalOptions="Center" Margin="0,0,3,0" />
+                <Label Text="Locatie: " FontSize="24" VerticalOptions="Center" Margin="0,0,3,0" />
                 <Label Text=" " FontSize="24" VerticalOptions="Center" Margin="0,0,3,0" />
                 <Label x:Name="campingSpotNumberLabel" FontSize="24" VerticalOptions="Center" Margin="0,0,3,0" />
                 <BoxView WidthRequest="20" HeightRequest="20" CornerRadius="10" Color="Green" VerticalOptions="Center" />
@@ -31,7 +31,6 @@
 
             <StackLayout Orientation="Horizontal">
                 <Entry Placeholder="Voornaam *" x:Name="firstNameEntry" HorizontalOptions="FillAndExpand" />
-                <Entry Placeholder="Tussenvoegsel" x:Name="middleNameEntry" HorizontalOptions="FillAndExpand" />
                 <Entry Placeholder="Achternaam *" x:Name="lastNameEntry" HorizontalOptions="FillAndExpand" />
             </StackLayout>
 
@@ -39,7 +38,6 @@
             <Entry Placeholder="E-mailadres *" Keyboard="Email" x:Name="emailEntry" />
 
             <Entry Placeholder="Totaal aantal kampeerders *" Keyboard="Numeric" x:Name="totalCampersEntry" />
-            <Entry Placeholder="Waarvan onder de 12 jaar *" Keyboard="Numeric" x:Name="under12Entry" />
 
             <Editor Placeholder="Bijzonderheden:" AutoSize="TextChanges" x:Name="specialNotesEditor" HeightRequest="150" />
 

--- a/CampingD1/ReservationApp/ReservationPage.xaml.cs
+++ b/CampingD1/ReservationApp/ReservationPage.xaml.cs
@@ -16,7 +16,7 @@ namespace ReservationApp
             _spotDetails = spotDetails;
 
             // Stel het label in met de beschrijving of nummer van de plek
-            campingSpotNumberLabel.Text = _spotDetails.Id.ToString();
+            campingSpotNumberLabel.Text = _spotDetails.Description.ToString();
 
             arrivalDatePicker.MinimumDate = DateTime.Today;
             departureDatePicker.MinimumDate = DateTime.Today.AddDays(1);
@@ -34,14 +34,13 @@ namespace ReservationApp
                 string.IsNullOrWhiteSpace(phoneEntry.Text) ||
                 string.IsNullOrWhiteSpace(emailEntry.Text) ||
                 string.IsNullOrWhiteSpace(totalCampersEntry.Text) ||
-                string.IsNullOrWhiteSpace(under12Entry.Text) ||
                 arrivalDatePicker.Date == null ||
                 departureDatePicker.Date == null)
             {
                 errorLabel.Text = "Alle verplichte velden moeten worden ingevuld.";
                 errorLabel.IsVisible = true;
             }
-            else if (!emailEntry.Text.Contains("@"))
+            else if (!emailEntry.Text.Contains("@") || emailEntry.Text.Length < 5)
             {
                 errorLabel.Text = "Controleer uw e-mailadres.";
                 errorLabel.IsVisible = true;
@@ -54,7 +53,6 @@ namespace ReservationApp
                 var phone = phoneEntry.Text;
                 var email = emailEntry.Text;
                 var totalCampers = int.TryParse(totalCampersEntry.Text, out int parsedTotalCampers) ? parsedTotalCampers : 0;
-                var under12 = int.TryParse(under12Entry.Text, out int parsedUnder12) ? parsedUnder12 : 0;
                 var specialNotes = specialNotesEditor.Text;
 
                 // Verkrijg de geselecteerde data
@@ -91,51 +89,50 @@ namespace ReservationApp
                             {
                                 Spacing = 20,
                                 Children = {
-                    // Header label
-                    new Label
-                    {
-                        Text = "✅ Bevestiging",
-                        FontSize = 24,
-                        FontAttributes = FontAttributes.Bold,
-                        HorizontalTextAlignment = TextAlignment.Center,
-                        TextColor = Color.FromArgb("#333333")
-                    },
-                    
-                    // Content label
-                    new Label
-                    {
-                        Text = $"Reservering succesvol opgeslagen!\n" +
-                               $"U krijgt een bevistigeningsmail!\n" + 
-                               $"📍 Naam: {firstName} {lastName}\n" +
-                               $"📞 Telefoon: {phone}\n" +
-                               $"📧 Email: {email}\n" +
-                               $"👨‍👩‍👧‍👦 Aantal kampeerders: {totalCampers}\n" +
-                               $"👶 Onder 12 jaar: {under12}\n" +
-                               $"📝 Bijzonderheden: {specialNotes}",
-                        FontSize = 16,
-                        TextColor = Color.FromArgb("#555555"),
-                        LineHeight = 1.5
-                    },
-                    
-                    // Return to map button
-                    new Button
-                    {
-                        Text = "🔙 Terug naar Kaart",
-                        BackgroundColor = Color.FromArgb("#007BFF"),
-                        TextColor = Colors.White,
-                        CornerRadius = 12,
-                        FontSize = 18,
-                        HeightRequest = 50,
-                        HorizontalOptions = LayoutOptions.FillAndExpand,
-                        Command = new Command(async () =>
-                        {
-                            confirmationPopup.Close(); // Sluit de pop-up
-                            await Application.Current.MainPage.Navigation.PopToRootAsync(); // Ga terug naar MapScreenCustomer
-                        })
-                    }
-                }
+                                    // Header label
+                                    new Label
+                                    {
+                                        Text = "✅ Bevestiging",
+                                        FontSize = 24,
+                                        FontAttributes = FontAttributes.Bold,
+                                        HorizontalTextAlignment = TextAlignment.Center,
+                                        TextColor = Color.FromArgb("#333333")
+                                    },
+                                    
+                                    // Content label
+                                    new Label
+                                    {
+                                        Text = $"Reservering succesvol opgeslagen!\n" +
+                                               $"📍 Naam: {firstName} {lastName}\n" +
+                                               $"📞 Telefoon: {phone}\n" +
+                                               $"📧 Email: {email}\n" +
+                                               $"👨‍👩‍👧‍👦 Aantal kampeerders: {totalCampers}\n" +
+                                               $"📝 Bijzonderheden: {specialNotes}",
+                                        FontSize = 16,
+                                        TextColor = Color.FromArgb("#555555"),
+                                        LineHeight = 1.5
+                                    },
+                                    
+                                    // Return to map button
+                                    new Button
+                                    {
+                                        Text = "🔙 Terug naar Kaart",
+                                        BackgroundColor = Color.FromArgb("#007BFF"),
+                                        TextColor = Colors.White,
+                                        CornerRadius = 12,
+                                        FontSize = 18,
+                                        HeightRequest = 50,
+                                        HorizontalOptions = LayoutOptions.FillAndExpand,
+                                        Command = new Command(async () =>
+                                        {
+                                            confirmationPopup.Close(); // Sluit de pop-up
+                                            await Application.Current.MainPage.Navigation.PopToRootAsync(); // Ga terug naar MapScreenCustomer
+                                        })
+                                    }
+                                }
                             }
-                        }
+                        },
+                        CanBeDismissedByTappingOutsideOfPopup = false // Prevent closing when tapping outside
                     };
 
                     // Toon de pop-up
@@ -149,9 +146,6 @@ namespace ReservationApp
                     errorLabel.Text = $"Er is een fout opgetreden: {ex.Message}";
                     errorLabel.IsVisible = true;
                 }
-
-
-
             }
         }
     }

--- a/CampingD1/ReservationApp/ReservationPopup.cs
+++ b/CampingD1/ReservationApp/ReservationPopup.cs
@@ -18,13 +18,21 @@ namespace ReservationApp
             string ConvertBoolToYesNo(bool value) => value ? "Ja" : "Nee";
 
             // Show camping spot details with improved formatting
-            var descriptionLabel = new Label
+            var nameLabel = new Label
             {
-                Text = $"Spot: {_campingSpot.Description}",
+                Text = $"Plek: {_campingSpot.SpotName}",
                 FontSize = 20,
                 FontAttributes = FontAttributes.Bold,
                 TextColor = Colors.Black,
                 HorizontalOptions = LayoutOptions.Center
+            };           
+            
+            var descriptionLabel = new Label
+            {
+                Text = $"Beschrijving: {_campingSpot.Description}",
+                FontSize = 16,
+                TextColor = Colors.Gray,
+                HorizontalOptions = LayoutOptions.Start
             };
 
             var powerLabel = new Label
@@ -37,7 +45,7 @@ namespace ReservationApp
 
             var wifiLabel = new Label
             {
-                Text = $"Internet connectie: {ConvertBoolToYesNo(_campingSpot.Wifi)}",
+                Text = $"WiFi: {ConvertBoolToYesNo(_campingSpot.Wifi)}",
                 FontSize = 16,
                 TextColor = Colors.Gray,
                 HorizontalOptions = LayoutOptions.Start
@@ -109,6 +117,7 @@ namespace ReservationApp
                 {
                     Spacing = 10,
                     Children = {
+                        nameLabel,
                         descriptionLabel,
                         powerLabel,
                         wifiLabel,

--- a/CampingD1/ReservationApp/ReservationPopup.cs
+++ b/CampingD1/ReservationApp/ReservationPopup.cs
@@ -14,6 +14,9 @@ namespace ReservationApp
         {
             _campingSpot = campingSpot;
 
+            // Helper functie om true/false naar "ja"/"nee" te converteren
+            string ConvertBoolToYesNo(bool value) => value ? "Ja" : "Nee";
+
             // Show camping spot details with improved formatting
             var descriptionLabel = new Label
             {
@@ -26,7 +29,7 @@ namespace ReservationApp
 
             var powerLabel = new Label
             {
-                Text = $"Power: {_campingSpot.Power}",
+                Text = $"Stroom: {ConvertBoolToYesNo(_campingSpot.Power)}",
                 FontSize = 16,
                 TextColor = Colors.Gray,
                 HorizontalOptions = LayoutOptions.Start
@@ -34,7 +37,7 @@ namespace ReservationApp
 
             var wifiLabel = new Label
             {
-                Text = $"WiFi: {_campingSpot.Wifi}",
+                Text = $"Internet connectie: {ConvertBoolToYesNo(_campingSpot.Wifi)}",
                 FontSize = 16,
                 TextColor = Colors.Gray,
                 HorizontalOptions = LayoutOptions.Start
@@ -42,7 +45,7 @@ namespace ReservationApp
 
             var waterLabel = new Label
             {
-                Text = $"Water: {_campingSpot.Water}",
+                Text = $"Water: {ConvertBoolToYesNo(_campingSpot.Water)}",
                 FontSize = 16,
                 TextColor = Colors.Gray,
                 HorizontalOptions = LayoutOptions.Start
@@ -50,7 +53,7 @@ namespace ReservationApp
 
             var maxPersonsLabel = new Label
             {
-                Text = $"Max Persons: {_campingSpot.MaxPersons}",
+                Text = $"Maximaal aantal personen: {_campingSpot.MaxPersons}",
                 FontSize = 16,
                 TextColor = Colors.Gray,
                 HorizontalOptions = LayoutOptions.Start


### PR DESCRIPTION
- Alle teksten die de klant ziet moet nederlands zijn.
- Ik zag dat er een nieuwe libary is gebruikt en gedownload. Dit moet beargumenteerd worden in het technisch ontwerp waarom dit is gedaan.
- In de popup van een cirkel alles even netjes renderen. Er staat nu nu bijvoorbeeld lettelrijk uit de database overgenomen: “maxPersons” en “wifi: true”. Booleans even veranderen naar Ja en Nee, maxPersons naar Maximaal aantal personen. Etc voor elk veld.
- Als je de app opent moeten de cirkels al standaard geladen worden met de datums ingesteld op vandaagn aankomst en morgen vertrek
- Het tussenvoegsel veld mag weg gehaald worden.
- aantal kinderen veld gebruiken we niet. dus mag weg.
- Als je vanuit een cirkel naar het reserveringsscherm gaat zijn de datums niet standaard ingevuld. Dit is wel wenselijk
- Als je vanuit een cirkel naar het reservringsscherm gaat staat er bovenin nu “Locatie {id}” Deze ID moet niet de id zijn maar de spot_name uit de database. Zie ERD
- Bij het maken van een reservering staat er de tekst dat er een mail uitgestuurd wordt. Dit gebeurt niet en gaat ook niet gebeuren
- Als je een reservering aanmaakt kan je naast de popup klikken en dan kan je weer opnieuw reserveren